### PR TITLE
Prefer fandol to arphic

### DIFF
--- a/tl-updates/updmap-hdr.cfg
+++ b/tl-updates/updmap-hdr.cfg
@@ -96,7 +96,7 @@ dvipdfmDownloadBase14 true
 # the respective map file used.
 #
 jaEmbed ipaex
-scEmbed arphic
+scEmbed fandol
 tcEmbed arphic
 koEmbed baekmuk
 


### PR DESCRIPTION
Both of them are shipped with TeX Live. But fandol fonts are higher quality than araphic.